### PR TITLE
Fix cookiecutter.json decoding

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,5 +13,5 @@
   "picasso": "n",
   "kotlin_android_extensions": "n",
   "anko": "n",
-  "coroutines": "n",
+  "coroutines": "n"
 }


### PR DESCRIPTION
Decoding error details: "Expecting property name: line 17 column 1 (char 559)"